### PR TITLE
Ekstazi Matrix HTML Report

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include resources *

--- a/pytest_ekstazi/console_scripts.py
+++ b/pytest_ekstazi/console_scripts.py
@@ -1,0 +1,35 @@
+import os
+import pathlib
+import argparse
+import tempfile
+import webbrowser
+
+import jinja2
+
+from .plugin import DEFAULT_CONFIG_FILE
+from .config import EkstaziConfiguration
+
+TEMPLATE_FOLDER = pathlib.Path(__file__).parent / 'resources'
+MATRIX_TEMPLATE_FILENAME = 'matrix_template.html'
+
+
+def ekstazi_matrix():
+    parser = argparse.ArgumentParser(description='Open HTML containing the Ekstazi matrix based on the configuration file',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    parser.add_argument('--ekstazi-file', default=DEFAULT_CONFIG_FILE, 
+        help='Ekstazi configuration file. The file contains the test cases\' file dependencies and the ' 
+             'hashes of their content.'
+    )
+
+    args = parser.parse_args()
+
+    configuration = EkstaziConfiguration(args.ekstazi_file)
+
+    template_environment = jinja2.Environment(loader=jinja2.FileSystemLoader(TEMPLATE_FOLDER))
+    template = template_environment.get_template(MATRIX_TEMPLATE_FILENAME)
+
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.html') as rendered_file:
+        rendered_file.write(template.render({'test_cases': configuration._dependencies.keys()}))
+
+    webbrowser.open('file://{}'.format(rendered_file.name))

--- a/pytest_ekstazi/resources/matrix_template.html
+++ b/pytest_ekstazi/resources/matrix_template.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ekstazi Matrix</title>
+</head>
+<body>
+    <h1>List of test cases</h1>
+    <ul>
+        {% for test_case in test_cases %}
+        <li>{{ test_case }}</li>
+        {% endfor %}
+    </ul>
+</body>
+</html>

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     url='https://github.com/Igorxp5/pytest-ekstazi',
     packages=['pytest_ekstazi'],
+    include_package_data=True,
     classifiers=[
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: MIT License',
@@ -24,8 +25,9 @@ setuptools.setup(
         'Framework :: Pytest'
     ],
     entry_points={
-        'pytest11': ['pytest_ekstazi = pytest_ekstazi.plugin']
+        'pytest11': ['pytest_ekstazi = pytest_ekstazi.plugin'],
+        'console_scripts': ['ekstazi_matrix = pytest_ekstazi.console_scripts:ekstazi_matrix']
     },
-    install_requires=['pytest'],
+    install_requires=['pytest', 'Jinja2'],
     python_requires='>=3.7',
 )


### PR DESCRIPTION
Create an entry point into setup file to open a browser with the Ekstazi Matri HTML report.

How to run: call `ekstazi_matrix` in the terminal.

Implements #9 